### PR TITLE
.gitignore を追加した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+theories/.*.aux
+theories/*.glob
+theories/*.vo
+theories/*.vok
+theories/*.vos
+
+.Makefile.d
+CoqMakefile.conf
+Makefile
+Makefile.conf


### PR DESCRIPTION
`configure.sh` や `make` を使うと生成されるファイルを含めないようにした。