### PR TITLE
PrimitiveSegment を別ファイルに分離

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,2 +1,3 @@
 -R theories scurve
+theories/PrimitiveSegment.v
 theories/Main.v

--- a/theories/Main.v
+++ b/theories/Main.v
@@ -1,60 +1,9 @@
 
 Require Import Stdlib.Reals.Reals.
 Require Import Stdlib.Lists.List.
+Require Import PrimitiveSegment.
 Open Scope R_scope.
 Import ListNotations.
-
-Inductive V : Set :=
-| n : V
-| s : V
-.
-
-Inductive H : Set :=
-| e : H
-| w : H
-.
-
-Inductive C : Set :=
-| cx : C
-| cc : C
-.
-
-Inductive Dir : Set :=
-| Ver : V -> Dir
-| Hor : H -> Dir
-.
-
-Definition i_v (v : V) : V :=
-match v with
-| n => s
-| s => n
-end.
-
-Definition i_h (h : H) : H :=
-match h with
-| e => w
-| w => e
-end.
-
-Definition i (d: Dir) : Dir :=
-match d with
-| Ver v => Ver (i_v v)
-| Hor h => Hor (i_h h)
-end.
-
-Definition i_c (c: C) : C :=
-match c with
-| cx => cc
-| cc => cx
-end. 
-
-(* PrimitiveSegment，単位セグメント *)
-Definition PrimitiveSegment := (V * H * C)%type.
-(* 各要素を取り出す *)
-Definition V_of (x:PrimitiveSegment) := fst(fst x).
-Definition H_of (x:PrimitiveSegment) := snd(fst x).
-Definition C_of (x:PrimitiveSegment) := snd x.
-
 
 (*セグメントは[0,1]->R*Rの関数
 埋め込み関係は次の条件を満たしたもの

--- a/theories/Main.v
+++ b/theories/Main.v
@@ -5,7 +5,11 @@ Require Import PrimitiveSegment.
 Open Scope R_scope.
 Import ListNotations.
 
-Definition H := H.  (* TODO: 証明のintros とかで名前付けをサボらない*)
+(*
+ * 自動で生成される名前がズレてしまうので無意味な定義を入れている。
+ * TODO: 証明のintros とかで名前付けをサボらない
+ *)
+Definition H := H.
 
 (*セグメントは[0,1]->R*Rの関数
 埋め込み関係は次の条件を満たしたもの

--- a/theories/Main.v
+++ b/theories/Main.v
@@ -5,6 +5,8 @@ Require Import PrimitiveSegment.
 Open Scope R_scope.
 Import ListNotations.
 
+Definition H := H.  (* TODO: 証明のintros とかで名前付けをサボらない*)
+
 (*セグメントは[0,1]->R*Rの関数
 埋め込み関係は次の条件を満たしたもの
 ・[0,1]で微分可能

--- a/theories/PrimitiveSegment.v
+++ b/theories/PrimitiveSegment.v
@@ -41,7 +41,7 @@ Definition i_c (c: C) : C :=
 match c with
 | cx => cc
 | cc => cx
-end. 
+end.
 
 (* PrimitiveSegment，単位セグメント *)
 Definition PrimitiveSegment := (V * H * C)%type.

--- a/theories/PrimitiveSegment.v
+++ b/theories/PrimitiveSegment.v
@@ -1,0 +1,51 @@
+
+Inductive V : Set :=
+| n : V
+| s : V
+.
+
+Inductive H : Set :=
+| e : H
+| w : H
+.
+
+Inductive C : Set :=
+| cx : C
+| cc : C
+.
+
+Inductive Dir : Set :=
+| Ver : V -> Dir
+| Hor : H -> Dir
+.
+
+Definition i_v (v : V) : V :=
+match v with
+| n => s
+| s => n
+end.
+
+Definition i_h (h : H) : H :=
+match h with
+| e => w
+| w => e
+end.
+
+Definition i (d: Dir) : Dir :=
+match d with
+| Ver v => Ver (i_v v)
+| Hor h => Hor (i_h h)
+end.
+
+Definition i_c (c: C) : C :=
+match c with
+| cx => cc
+| cc => cx
+end. 
+
+(* PrimitiveSegment，単位セグメント *)
+Definition PrimitiveSegment := (V * H * C)%type.
+(* 各要素を取り出す *)
+Definition V_of (x:PrimitiveSegment) := fst(fst x).
+Definition H_of (x:PrimitiveSegment) := snd(fst x).
+Definition C_of (x:PrimitiveSegment) := snd x.


### PR DESCRIPTION
したのですがコンパイルが通らなくなっちゃった……。

```
❯ make
ROCQ DEP VFILES
ROCQ compile theories/PrimitiveSegment.v
ROCQ compile theories/Main.v
File "./theories/Main.v", line 97, characters 16-18:
Error:
In environment
s' : Segment
c : C
x : R
H : embed (n, e, c) s'
H0 : fst (init s') <= x
H1 : x <= fst (term s')
The term "H1" has type "x <= fst (term s')" while it is expected to have type
 "fst (init s') <= x".
```