### PR TITLE
Fix all_prefix.

### DIFF
--- a/theories/ListExt.v
+++ b/theories/ListExt.v
@@ -26,8 +26,7 @@ Fixpoint all_prefix {A:Set} (xs : list A) : list (list A) :=
   match xs with
   | [] => [[]]
   | x::xs' =>
-      let ps := all_prefix xs' in
-      ps ++ map (fun ys => x :: ys) ps
+      [] :: map (fun ys => x :: ys) (all_prefix xs')
   end.
 
 Fixpoint all_sublists {A:Set} (xs: list A) : list (list A) :=


### PR DESCRIPTION
挙動が壊れていたので正しくしました。

```
Compute all_prefix [1;2;3].
     = [[]; [1]; [1; 2]; [1; 2; 3]]
     : list (list nat)
```