### PR TITLE
 :sparkles: Now, we can (xs =? ys) for Direction lists xs ys.

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -1,4 +1,6 @@
 -R theories scurve
+theories/Dec.v
+theories/Eq.v
 theories/ListExt.v
 theories/PrimitiveSegment.v
 theories/Main.v

--- a/theories/Dec.v
+++ b/theories/Dec.v
@@ -1,0 +1,51 @@
+Set Implicit Arguments.
+
+Definition dec P := {P} + {~P}.
+
+Definition not P (x: dec P) : dec (~P).
+  refine (match x with
+  | left p => right _
+  | right np => left _
+  end); tauto.
+Defined.
+
+Definition and P Q (x : dec P) (y : dec Q) : dec (P /\ Q) :=
+  match x with
+  | left p =>
+      match y with
+      | left q => left (conj p q)
+      | right nq => right (fun pq => nq (proj2 pq))
+      end
+  | right np => right (fun pq => np (proj1 pq))
+  end.
+
+Notation "p && q" := (and p q).
+
+Definition or P Q (x : dec P) (y : dec Q) : dec (P \/ Q) :=
+  match x with
+  | left p => left (or_introl p)
+  | right np =>
+      match y with
+      | left q => left (or_intror q)
+      | right nq => right (or_ind np nq)
+      end
+  end.
+Notation "p || q" := (or p q).
+
+Definition impl P Q (x : dec P) (y : dec Q) : dec (P -> Q) :=
+  match x with
+  | left p =>
+      match y with
+      | left q => left (fun _ => q)
+      | right nq => right (fun pq => nq (pq p))
+      end
+  | right np => left (fun p => False_rec _ (np p))
+  end.
+
+Notation "p -->? q" := (impl p q) (at level 40).
+
+Definition map P P' (f : P <-> P') (x : dec P) : dec P' :=
+  match x with
+  | left p => left (proj1 f p)
+  | right np => right (fun p' => np (proj2 f p'))
+  end.

--- a/theories/Eq.v
+++ b/theories/Eq.v
@@ -1,0 +1,82 @@
+Require Import String.
+Require Import Arith.
+Require Import Dec.
+Set Implicit Arguments.
+
+Record eqDec : Type := Pack {
+  sort : Type;
+  eq_dec :  forall x y: sort, {x = y} + {x <> y}
+}.
+
+Canonical nat_eqDec := @Pack nat Nat.eq_dec.
+
+Canonical bool_eqDec : eqDec := @Pack bool Bool.bool_dec.
+
+Notation "x =? y" := (@eq_dec _ x y). (* level 70 *)
+Notation "x <>? y" := (Dec.not (@eq_dec _ x y)) (at level 70).
+
+(* Compute (1 =? 2).
+Compute (true =? false). *)
+
+Definition prod_cmp (eqA eqB: eqDec) (x y: eqA.(sort) * eqB.(sort)) : {x = y} + {x <> y}.
+  refine (map  _ (eqA.(eq_dec) (fst x) (fst y) && eqB.(eq_dec) (snd x) (snd y))).
+  refine (
+      let '(x1, x2) := x in
+      let '(y1, y2) := y in
+      conj (fun '(conj e1 e2) => _) (fun b => _)).
+  - simpl in e1, e2. now rewrite e1, e2.
+  - simpl.
+    split.
+    -- apply (f_equal fst b).
+    -- apply (f_equal snd b).
+Defined.
+
+Canonical prod_eqDec (eqA eqB : eqDec) : eqDec :=
+  @Pack (eqA.(sort) * eqB.(sort)) (@prod_cmp eqA eqB).
+
+Fixpoint list_dec (eqA : eqDec) (x y: list eqA.(sort)) : dec (x = y).
+  destruct x, y; [now left| now right| now right| ].
+  destruct (s =? s0); [| right].
+  - subst s0.
+    destruct (list_dec eqA x y); [left | right].
+    + now subst y.
+    + now injection.
+  - now injection.
+Defined.
+
+Canonical list_eqDec (eqA: eqDec) : eqDec :=
+  @Pack (list eqA.(sort)) (list_dec eqA).
+
+Definition option_dec (eqA : eqDec) (x y: option eqA.(sort)) : dec (x = y).
+  refine (match x, y with
+          | None, None => left _
+          | Some a, Some b => if a =? b then left _
+                              else right _
+          | Some _, None => right _
+          | None, Some _ => right _
+          end); try discriminate.
+  - now rewrite e.
+  - now injection 1.
+  - now auto.
+Defined.
+
+Canonical option_eqDec (eqA : eqDec) : eqDec :=
+  @Pack (option eqA.(sort)) (option_dec eqA).
+
+(*Require Import List.
+Import ListNotations.
+Check [1;2;3] =? [4;5]. *)
+
+Inductive yesno :=
+| Yes : yesno
+| No  : yesno.
+
+Definition yesno_dec (x y: yesno) : {x = y} + {x <> y}.
+  destruct x, y.
+  - now left.
+  - now right.
+  - now right.
+  - now left.
+Defined.
+
+Canonical yesno_eqDec := @Pack yesno yesno_dec.

--- a/theories/Reduction.v
+++ b/theories/Reduction.v
@@ -3,12 +3,22 @@ Require Import ZArith.
 Require Import PrimitiveSegment.
 Import ListNotations.
 Open Scope Z_scope.
+Require Import Eq.
 
 (* 向き *)
 Inductive Direction : Set :=
 | Plus : Direction
 | Minus : Direction
 .
+
+Definition Direction_dec: forall (x y: Direction), {x = y} + {x <> y}.
+  refine (fun x y => match x, y with
+                  | Plus, Plus => left _
+                  | Minus, Minus => left _
+                  | _, _ => right _
+                  end); now auto.
+Defined.
+Canonical Direction_eqDec := @Pack _ Direction_dec.
 
 (* 単位セグメントから向きへの変換 *)
 Definition orn (x:PrimitiveSegment) : Direction :=


### PR DESCRIPTION
Fix https://github.com/proof-ninja/coq-scurve/issues/28