### PR TITLE
Y tak6@rotatedif eight

### DIFF
--- a/theories/Admissible.v
+++ b/theories/Admissible.v
@@ -171,11 +171,11 @@ Definition all_admissibles_quotient :=
 
 Definition inv ds := map (fun x => match x with | Plus => Minus | Minus => Plus end) ds.
 
-Inductive rev_inv_sim : list Direction -> list Direction -> Prop :=
-| Equal : forall ds, rev_inv_sim ds ds
-| Rev : forall ds, rev_inv_sim ds (rev ds)
-| Inv : forall ds, rev_inv_sim ds (inv ds)
-| RevInv : forall ds, rev_inv_sim ds (rev (inv ds))
+Inductive Equiv : list Direction -> list Direction -> Prop :=
+| Equal : forall ds, Equiv ds ds
+| Rev : forall ds, Equiv ds (rev ds)
+| Inv : forall ds, Equiv ds (inv ds)
+| RevInv : forall ds, Equiv ds (rev (inv ds))
 .
 
 Ltac try_all_list lst :=
@@ -185,14 +185,14 @@ Ltac try_all_list lst :=
   end.
 
 Lemma consist_quotient: 
-forall ds, In ds all_admissibles -> exists repds, rev_inv_sim ds repds /\ In repds all_admissibles_quotient.
+forall ds, In ds all_admissibles -> exists repds, Equiv ds repds /\ In repds all_admissibles_quotient.
 Proof.
   intros ds HIn. repeat destruct HIn as [Heq | HIn]
   ; try_all_list all_admissibles_quotient.
 Qed.
 
 Corollary reduced_admissible_form_quotient:
-forall ds dsr, AdmissibleDirs ds -> reduced ds dsr -> exists repds, rev_inv_sim dsr repds /\ In repds all_admissibles_quotient.
+forall ds dsr, AdmissibleDirs ds -> reduced ds dsr -> exists repds, Equiv dsr repds /\ In repds all_admissibles_quotient.
 Proof.
   intros ds dsr AD Reduced. apply consist_quotient. exact (reduced_admissible_form ds dsr AD Reduced).
 Qed.


### PR DESCRIPTION
- 長さが8以上ならば回転差が4以上であることの証明
- issue #65, #66
- 論文で上がった11種類のリストと，反転，正負の入れ替えの関係の定義，及び，28のリストがその同値関係の下で11のものと等価であることの証明