### PR TITLE
Rocqnavi でドキュメントを生成するように設定 Closes #71

### DIFF
--- a/.github/workflows/deploy_rocqnavi_doc.yml
+++ b/.github/workflows/deploy_rocqnavi_doc.yml
@@ -1,0 +1,75 @@
+name: Build HTML using Rocqnavi and Deploy
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: 5
+          opam-repositories: |
+            default: https://github.com/ocaml/opam-repository.git
+            rocq-released: https://rocq-prover.org/opam/released
+
+      - name: Install dependencies
+        run: opam install -y . --deps-only
+
+      - name: Build project
+        run: |
+          opam exec -- ./configure.sh
+          opam exec -- make
+
+      - name: Install Rocqnavi
+        run: opam install -y . --deps-only --with-doc
+
+      - name: Build HTML using rocqnavi
+        run: |
+          mkdir html
+          opam exec -- rocqnavi \
+            -Q theories scurve \
+            -d html \
+            -title "Formalization of Admissibility of Qualitatively Represented Curves" \
+            $(find theories -name "*.v" -or -name "*.glob")
+
+      - name: Upload static files as artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: html/
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/coq-scurve.opam
+++ b/coq-scurve.opam
@@ -10,6 +10,7 @@ dev-repo: "git+https://github.com/proof-ninja/coq-scurve"
 depends: [
   "rocq-prover"
   "rocq-equations"
+  "rocq-navi" {with-doc}
 ]
 
 authors: [


### PR DESCRIPTION
#71 

手元で rocq-navi を動かしての動作確認は完了。

## 備考
main ブランチにマージした段階でドキュメントが生成されるようにしているが、これでいいか。
（向き先が develop になっちゃってるから、 main に rebase した後に main に向け直す？）

## TODO:
- [ ] Repository の Setting で GitHub Pages を有効化
  1. GitHubリポジトリの Settings → Pages に移動
  2. Source を GitHub Actions に設定
- [ ] 動作確認